### PR TITLE
FIx :  Added page visibility detection to resume polling and auto-navigate on completion

### DIFF
--- a/src/components/models/ModelSelectionScreen.tsx
+++ b/src/components/models/ModelSelectionScreen.tsx
@@ -8,7 +8,7 @@ import { staggerContainer, staggerItem } from '@/utils/transitions';
 import { useForecast } from '@/context/ForecastContext';
 
 const steps = ["Onboarding", "Data Source", "Model Selection", "Generated Forecast", "Dashboard"];
-const POLLING_INTERVAL = 10 * 1000; // 10 minutes
+// const POLLING_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
 const ModelSelectionScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -47,7 +47,7 @@ const ModelSelectionScreen: React.FC = () => {
       const checkStatus = async () => {
         console.log('[DEBUG] Polling: Checking forecast status...');
         try {
-          const res = await fetch("https://featurebox-ai-backend-service-666676702816.us-west1.run.app/status");
+          const res = await fetch(`${import.meta.env.VITE_AUTH_API_URL}/status`);
           if (!res.ok) throw new Error(`Status check failed: ${res.status}`);
           const data = await res.json();
           console.log('[DEBUG] Forecast status:', data);


### PR DESCRIPTION
Chrome throttles timers in background tabs, so our status polling stalls when the user switches away.
When the user returns, the UI can remain stuck showing “running”.

The fix:
- Prevents the UI from appearing stuck when the tab was backgrounded.
- Ensures users see completion immediately upon returning to the tab.



